### PR TITLE
Feat/#32 : 주문 요청 시 유저 id를 포함하여 요청 (로그인이 완료된 유저만 가능하도록 수정 예정)

### DIFF
--- a/backend/src/main/java/io/back3nd/backend/domain/api/OrderController.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/api/OrderController.java
@@ -1,12 +1,16 @@
 package io.back3nd.backend.domain.api;
 
 import io.back3nd.backend.domain.app.OrderService;
+import io.back3nd.backend.domain.dao.UsersRepository;
 import io.back3nd.backend.domain.dto.OrderRequest;
 import io.back3nd.backend.domain.dto.OrderResponse;
+import io.back3nd.backend.domain.entity.Users;
 import io.back3nd.backend.global.common.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 import static io.back3nd.backend.global.common.StatusCode.*;
 
@@ -16,12 +20,18 @@ import static io.back3nd.backend.global.common.StatusCode.*;
 public class OrderController {
 
     private final OrderService orderService;
+    private final UsersRepository usersRepository;
 
     @PostMapping("/orders")
     public ResponseEntity<CommonResponse<OrderResponse>> doOrder(
-            @RequestBody OrderRequest orderRequest) {
+            @RequestBody OrderRequest orderRequest,
+            @RequestParam Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        OrderResponse orderResponse = orderService.doOrder(orderRequest, user);
         return ResponseEntity.status(ORDER_SUCCESS.getStatus())
-                .body(CommonResponse.from(ORDER_SUCCESS.getMessage(), orderService.doOrder(orderRequest)));
+                .body(CommonResponse.from(ORDER_SUCCESS.getMessage(), orderResponse));
     }
 
     @GetMapping("/orders/{id}")

--- a/backend/src/main/java/io/back3nd/backend/domain/app/OrderService.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/app/OrderService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/io/back3nd/backend/domain/app/OrderService.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/app/OrderService.java
@@ -4,10 +4,7 @@ import io.back3nd.backend.domain.dao.ItemsRepository;
 import io.back3nd.backend.domain.dao.OrdersRepository;
 import io.back3nd.backend.domain.dto.OrderRequest;
 import io.back3nd.backend.domain.dto.OrderResponse;
-import io.back3nd.backend.domain.entity.Items;
-import io.back3nd.backend.domain.entity.OrderItems;
-import io.back3nd.backend.domain.entity.Orders;
-import io.back3nd.backend.domain.entity.Status;
+import io.back3nd.backend.domain.entity.*;
 import io.back3nd.backend.global.exception.InvalidOrderException;
 import io.back3nd.backend.global.exception.InvalidOrderStateException;
 import lombok.RequiredArgsConstructor;
@@ -26,19 +23,21 @@ public class OrderService {
     private final ItemsRepository itemsRepository;
     private final OrdersRepository ordersRepository;
 
-    public OrderResponse doOrder(OrderRequest orderRequest) {
+    public OrderResponse doOrder(OrderRequest orderRequest, Users user) {
         List<OrderItems> orderItems = orderRequest.getOrderItems().stream().map(req -> {
             Items item = itemsRepository.findById(req.getItemId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이템 번호 입니다."));
-            try {
-                item.decreaseStock(req.getQuantity());
-            } catch (IllegalArgumentException e) {
-                throw e;
-            }
+            item.decreaseStock(req.getQuantity()); //에러가 두번 던져져서 리팩토링
 
             return OrderItems.builder().item(item).quantity(req.getQuantity()).build();
         }).toList();
 
-        Orders orders = Orders.builder().email(orderRequest.getEmail()).address(orderRequest.getAddress()).zipcode(orderRequest.getZipcode()).build();
+        Orders orders = Orders.builder()
+                .email(orderRequest.getEmail())
+                .address(orderRequest.getAddress())
+                .zipcode(orderRequest.getZipcode())
+                .build();
+
+        orders.setUser(user);  // 로그인된 사용자와 연관
 
         for (OrderItems orderItem : orderItems) {
             orderItem.setOrder(orders);

--- a/backend/src/main/java/io/back3nd/backend/domain/dao/UsersRepository.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/dao/UsersRepository.java
@@ -3,5 +3,8 @@ package io.back3nd.backend.domain.dao;
 import io.back3nd.backend.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UsersRepository extends JpaRepository<Users, Long> {
+    Optional<Users> findByEmail(String email);
 }

--- a/backend/src/main/java/io/back3nd/backend/domain/dto/ItemRequest.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/dto/ItemRequest.java
@@ -1,8 +1,10 @@
 package io.back3nd.backend.domain.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ItemRequest {
 
     private String name;

--- a/backend/src/main/java/io/back3nd/backend/domain/entity/Users.java
+++ b/backend/src/main/java/io/back3nd/backend/domain/entity/Users.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Setter
 @NoArgsConstructor
 @Getter
 public class Users {


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 요청 시 유저 id를 포함하여 요청

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
서비스와 컨트롤러에 요청 시 유저 아이디가 포함되도록 작성

테스트 유저와 테스트 아이템 생성
![image](https://github.com/user-attachments/assets/6579854c-e509-4131-be5a-b16c46745bdc)

주문 생성 테스트
![image](https://github.com/user-attachments/assets/3f3c5b3c-9c0d-4bf4-a164-2d233409fcbe)

테스트 유저의 정보가 필수
![image](https://github.com/user-attachments/assets/a0bd63d5-84ec-4b19-8704-8ae94b2f5b49)


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
